### PR TITLE
Updated the length for Seychelles

### DIFF
--- a/lib/countries.dart
+++ b/lib/countries.dart
@@ -6858,8 +6858,8 @@ const List<Country> countries = [
     flag: "🇸🇨",
     code: "SC",
     dialCode: "248",
-    minLength: 6,
-    maxLength: 6,
+    minLength: 7,
+    maxLength: 7,
   ),
   Country(
     name: "Sierra Leone",


### PR DESCRIPTION
The length of phone numbers in Seychelles was incorrectly marked as 6, but it is actually 7. Created this pull request to get this updated.

### Reference
- https://en.wikipedia.org/wiki/Telephone_numbers_in_Seychelles