### PR TITLE
Pass country ISO code for validating MobileNumbers

### DIFF
--- a/lib/mobile_number.dart
+++ b/lib/mobile_number.dart
@@ -49,7 +49,7 @@ class MobileNumber {
   }
 
   bool isValidNumber() {
-    Country country = getCountry(completeNumber);
+    Country country = getCountry(completeNumber, countryISOCode);
     if (number.length < country.minLength) {
       throw NumberTooShortException();
     }
@@ -64,7 +64,7 @@ class MobileNumber {
     return countryCode + number;
   }
 
-  static Country getCountry(String mobileNumber) {
+  static Country getCountry(String mobileNumber, [String? countryISOCode]) {
     if (mobileNumber == "") {
       throw NumberTooShortException();
     }
@@ -73,6 +73,10 @@ class MobileNumber {
 
     if (!validMobileNumber.hasMatch(mobileNumber)) {
       throw InvalidCharactersException();
+    }
+
+    if(countryISOCode != null){
+      return countries.firstWhere((country) => countryISOCode == country.code);
     }
 
     if (mobileNumber.startsWith('+')) {


### PR DESCRIPTION
`MobileNumber` that has been entered manually through `IntlMobileField` already contains the ISO code of the country.
When validating a `MobileNumber` entered manually, country can be obtained by looking at the exact match of the ISO code, instead of looking at matches of dial code an region code, which currently provide errors due to multiple countries having the same dial code and the same (empty by default) region code.

Fixes #53 .

Remaining functionality of `MobileNumber.fromCompleteNumber` needs to be revised additionally.